### PR TITLE
記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < ApplicationController
+  def index
+    @articles = Article.all
+    # render json: @articles
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -4,4 +4,6 @@ class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
   def thumbnail_url
     object.thumbnail&.url
   end
+
+  json.array! @articles, partial: 'api/v1/articles/article', as: :article
 end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+
+  describe "GET /index" do
+    it "returns http success" do
+      get "/api/v1/articles/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
`bundle exec rails g controller api/v1/articles index`でcontrollerとテストファイル作成
indexメソッドにモデルから記事全部もってくる記述を追加
作成したarticle_preview_serializer.rbに処理をjsonで返す記述を追加