### PR TITLE
記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
-class Api::V1::ArticlesController < ApplicationController
-  def index
-    @articles = Article.all
-    # render json: @articles
+module Api::V1
+  class ArticlesController < BaseApiController # base_api_controller を継承
+    def index
+      articles = Article.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
   end
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,9 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :published_at, :thumbnail_url
-
-  def thumbnail_url
-    object.thumbnail&.url
-  end
-
-  json.array! @articles, partial: 'api/v1/articles/article', as: :article
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+    attributes :id, :name, :email
+  end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -11,8 +11,8 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "テスト記事" }
-    body { "テスト本文" }
-    association :user
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
+    user
   end
 end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -1,12 +1,22 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
 
-  describe "GET /index" do
-    it "returns http success" do
-      get "/api/v1/articles/index"
-      expect(response).to have_http_status(:success)
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
-
 end


### PR DESCRIPTION
### タスク内容

- [ active_model_serializers](https://github.com/rails-api/active_model_serializers) を使って、記事の一覧を json で返す機能を実装しよう。

その際、serializer は記事の一覧とその他の処理の API 関してはレスポンスの内容を分けたいので、
/app/serializers/api/v1/article_preview_serializer.rb
に 記事一覧の serializer を作成して実装してください。

- request spec を実装しよう。

### 一覧機能の仕様

- 記事の一覧に関しては誰でもみれるようにする
- 記事の一覧機能のレスポンスには本文は含めない
- 記事の更新順に取得する

（記事の一覧をフロントで表示する際の日付も、更新日をもとに表示する）