### PR TITLE
create, update, destroy

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -12,27 +12,19 @@ module Api::V1
     end
 
     def create
-      article = Article.new(article_params)
-      if article.save
-        render json: article, serializer: Api::V1::ArticleSerializer
-      else
-        render json: { errors: article.errors.full_messages }, status: :unprocessable_entity
-      end
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def update
-      article = Article.find(params[:id])
-      if article.update(article_params)
-        render json: article, serializer: Api::V1::ArticleSerializer
-      else
-        render json: { errors: article.errors.full_messages }, status: :unprocessable_entity
-      end
+      article = current_user.articles.find(params[:id])
+      article.update!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def destroy
-      article = Article.find(params[:id])
+      article = current_user.articles.find(params[:id])
       article.destroy!
-      render json: { message: "Article deleted successfully" }, status: :ok
     end
 
     private

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  # current_user のダミーコード
   def current_user
-    # 通常は Devise Token Auth が提供する current_user があるが、
-    # テスト中だけここが使われるようにする
-    User.first # 仮に users テーブルの先頭のユーザーを返す
+    @current_user ||= User.first
   end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -61,3 +61,7 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+# context ごとに let! を使い分けたい場合があるため無効に
+RSpec/LetSetup:
+  Enabled: false

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -35,7 +35,4 @@ FactoryBot.define do
     password_confirmation { "password" }
     confirmed_at { Time.current }
   end
-
-  factory :dummy_user, parent: :user do
-    email { "dummy@example.com" }
 end


### PR DESCRIPTION
ダミーの current_userメソッドを定義する。
テストにスタブを定義する。

記事の作成はログインしているユーザーだけができる操作です。

ログインユーザーは devise_token_auth gem で current_user という変数に入るようになるので、ダミーとして base_api_controller にこのメソッドを定義して、仮実装として「users テーブルの一番初めのユーザー」を引用するようにしましょう。

それができたら、新規作成する記事の user_id が current_user の id になるような API を実装してください。

最後に request のテストを書いてください。ただし、このテストでは、仮実装である base_api_controller の current_user をテストのときだけ別の値として参照するようにしてあげる必要があります。(これを「スタブ, stub」と呼びます)

具体的にはテストで allow_any_instance_of メソッドを使用して current_user を呼び出せるように実装します。 詳しい内容については以下のリンクを参考にしてみてください！